### PR TITLE
mc_build.sh: add a vendor flag

### DIFF
--- a/build/conf/local.conf
+++ b/build/conf/local.conf
@@ -82,7 +82,7 @@ MACHINE ??= "qemux86"
 #  - 'package_rpm' for rpm style packages
 # E.g.: PACKAGE_CLASSES ?= "package_rpm package_deb package_ipk"
 # We default to ipk:
-PACKAGE_CLASSES ?= "package_ipk"
+PACKAGE_CLASSES ?= "package_rpm"
 
 #
 # SDK/ADT target architecture

--- a/mc_build.sh
+++ b/mc_build.sh
@@ -11,6 +11,7 @@ usage(){
 build.sh
     -e (optional emit bitbake line. Doesn't run a build, just emits what would run.)
     -m machine
+    -v vendor (optional. Some machines we can extract vendor from the name. Some we can't)
     -c container_mc_config:container_image[,container_mc_config:container_image,...]
     -h host_mc_config:host_image
     -d container_image[,container_image]    (optional disable autostart for specified containers)
@@ -21,12 +22,13 @@ EOF
 parse_args(){
     [ $# -eq 0 ] && usage
 
-    while getopts ":em:h:c:d:" opt; do
+    while getopts ":em:h:c:v:d:" opt; do
         case ${opt} in
             e ) EMIT="1" ;;		
             m ) MACHINE=$OPTARG ;;
             h ) HOST=$OPTARG ;;
             c ) CONTAINERS=$OPTARG ;;
+	    v ) VENDOR=$OPTARG ;;
             d ) DISABLE=$OPTARG ;;
             \? ) error "Unknown option -$OPTARG" ;;
             : ) error "Missing option argument for -$OPTARG" ;;
@@ -46,9 +48,12 @@ build(){
     local CONTAINER_DEPENDS=""
     local BUILD_ARGS=""
     local MC_HOST=""
-    local VENDOR=$(echo "$MACHINE"|cut -d'-' -f1)
 
     declare -a GUESTS
+
+    if [ -z "$VENDOR" ]; then
+	    local VENDOR=$(echo "$MACHINE"|cut -d'-' -f1)
+    fi
 
     if [ ! -z "$HOST" ]; then
         HOSTCONFIG=$(echo "$HOST" | cut -d':' -f1)


### PR DESCRIPTION
Standards are great. Unfortunately ONL standards for naming are a bit
all over the place, so we need to add a vendor flag as there are some
machines whose vendor we can't extract.

Signed-off-by: Eilís Ní Fhlannagáin <pidge@toganlabs.com>