### PR TITLE
Add meta-intel for secure boot signing

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -30,3 +30,7 @@
 	path = meta-python2
 	url = https://git.openembedded.org/meta-python2
 	branch = dunfell
+[submodule "meta-intel"]
+	path = meta-intel
+	url = https://git.yoctoproject.org/git/meta-intel
+	branch = dunfell


### PR DESCRIPTION
Add meta-intel to the git submodules as it contains sbsign and other
code used for signing modules for secure boot. This will be useful later
for adding Intel/x86_64 optimisations such as microcode and drivers.

Signed-off-by: John Toomey <john@toganlabs.com>