### PR TITLE
bblayers.conf: remove meta-mion-sde for now

### DIFF
--- a/build/conf/bblayers.conf
+++ b/build/conf/bblayers.conf
@@ -22,5 +22,4 @@ BBLAYERS = " \
   ${MIONBASE}/meta-mion/meta-mion \
   ${MIONBASE}/meta-mion/meta-mion-simplerunc \
   ${MIONBASE}/meta-mion-bsp/meta-mion-${VENDOR} \
-  ${MIONBASE}/meta-mion-sde/meta-mion-barefoot \
 "


### PR DESCRIPTION
Until the CI system knows about it and more CI resources are
allocated, remove as this is killing builds.

Signed-off-by: Eilís Ní Fhlannagáin <pidge@toganlabs.com>