### PR TITLE
Remove mender from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,6 @@ BB_ENV_EXTRAWHITE="ALL_PROXY BBPATH_EXTRA BB_LOGCONFIG BB_NO_NETWORK BB_NUMBER_T
 ## Examples
 
 ```shell
-# Builds an ONLPV1 Guest, installs it on a mender updatable host and autostarts
-../mc_build.sh -m stordis-bf2556x-1t -c guest:mion-guest-onlpv1 -h host-mender:mion-host
 
 # Builds just an ONLPV1 Guest. Useful for creating update artifacts.
 ../mc_build.sh -m stordis-bf2556x-1t -c guest:mion-guest-onlpv1
@@ -91,8 +89,8 @@ BB_ENV_EXTRAWHITE="ALL_PROXY BBPATH_EXTRA BB_LOGCONFIG BB_NO_NETWORK BB_NUMBER_T
 ../mc_build.sh -m stordis-bf2556x-1t -h host-onie:mion-onie-image-onlpv1
 
 # Builds an image with ONLPV2 and ONLPV1 guests but disables ONLPV1 guest
-../mc_build.sh -m stordis-bf2556x-1t -c guest:mion-guest-onlpv1,guest:mion-guest-onlpv2 -h host-mender:mion-host -d mion-guest-onlpv1
+../mc_build.sh -m stordis-bf2556x-1t -c guest:mion-guest-onlpv1,guest:mion-guest-onlpv2 -h host-onie:mion-host -d mion-guest-onlpv1
 
 # Emits the commandline to build an image with ONLPV2 and ONLPV1 guests but disables ONLPV1 guest
-../mc_build.sh -e -m stordis-bf2556x-1t -c guest:mion-guest-onlpv1,guest:mion-guest-onlpv2 -h host-mender:mion-host -d mion-guest-onlpv1
+../mc_build.sh -e -m stordis-bf2556x-1t -c guest:mion-guest-onlpv1,guest:mion-guest-onlpv2 -h host-onie:mion-host -d mion-guest-onlpv1
 ```


### PR DESCRIPTION
With mender no longer in mion, references to mion in README.md needed to
be removed.

This will close mion #115

Signed-off-by: Katrina Prosise <igorina@toganlabs.com>

# mion

## Summary
- Description: _brief description of the bug that was fixed or the enhancement that was added_
- Affected hardware: _ALL -or- list specific switches_
- Issue: #115 

## Build and test
- [ ] Build command: N/A
- [x] Smoke tested on: Rendered using `grip` to check proper rendering 
- [x] all other steps taken to validate the pull request

## Checklist
- [x] All relevant issues have been updated
- [x] Reviewers have been added and a maintainer has been assigned
- [x] A Label, Project and Milestone have all been added
- [x] The relevant documentation/wiki/README have been updated and complies with the [NGL Style and Communication Guide](https://github.com/NetworkGradeLinux/mion-docs/wiki/Style-and-Communication-Guide)
- [ ] Git commits comply with the [NGL Git Workflow](https://github.com/NetworkGradeLinux/mion-docs/wiki/Git-Workflow) and have DCO signoff
- [ ] Yocto code complies with the [OpenEmbedded Style Guide](https://www.openembedded.org/wiki/Styleguide)
