### PR TITLE
Add ptest requirement to local.conf

### DIFF
--- a/build/conf/local.conf
+++ b/build/conf/local.conf
@@ -218,6 +218,12 @@ DISTRO="mion"
 
 GLIBC_ADDONS = "nptl"
 
+# To include the ptests in the image, they need to be included as a distro
+# feature.
+# This should be done when building mion-image-onlpv1-ptest.
+
+#DISTRO_FEATURES_append += " ptest"
+
 # The following lines need to be set if you want to do mc builds using bitbake.
 #
 # If you want to pass in CONTAINER_NAMES CONTAINER DEPENDS BBMULTICONFIG 


### PR DESCRIPTION
In order to build the ptest image, `ptest` needs to be added to
`DISTRO_FEATURES` in local.conf. A comment block was added, with the
required line commented out.

This commit will close mion #81

Signed-off-by: Katrina Prosise <igorina@toganlabs.com>

# mion

## Summary
- Description: **Variable to include ptests added as a comment in local.conf**
- Affected hardware: **qemu**
- Issue: #81 

## Build and test
- [x] Build command: `../mc_build.sh -v qemu -m qemux86-64 -h host-onie:mion-image-onlpv1-ptest`
- [x] Smoke tested on:  **qemux86-64**
- [ ] all other steps taken to validate the pull request: *N/A*

## Checklist
- [x] All relevant issues have been updated
- [x] Reviewers have been added and a maintainer has been assigned
- [x] A Label, Project and Milestone have all been added
- [x] The relevant documentation/wiki/README have been updated and complies with the [NGL Style and Communication Guide](https://github.com/NetworkGradeLinux/mion-docs/wiki/Style-and-Communication-Guide)
- [x] Git commits comply with the [NGL Git Workflow](https://github.com/NetworkGradeLinux/mion-docs/wiki/Git-Workflow) and have DCO signoff
- [x] Yocto code complies with the [OpenEmbedded Style Guide](https://www.openembedded.org/wiki/Styleguide)
