### PR TITLE
local.conf: Set default package feed URI

### DIFF
--- a/build/conf/local.conf
+++ b/build/conf/local.conf
@@ -83,6 +83,8 @@ MACHINE ??= "qemux86"
 # E.g.: PACKAGE_CLASSES ?= "package_rpm package_deb package_ipk"
 # We default to ipk:
 PACKAGE_CLASSES ?= "package_ipk"
+PACKAGE_FEED_URIS = "http://tilde.toganlabs.com/repo"
+PACKAGE_FEED_BASE_PATHS = "${DISTRO_DATE}"
 
 #
 # SDK/ADT target architecture


### PR DESCRIPTION
Signed-off-by: John Toomey <john@toganlabs.com>

# mion

## Summary
- Description: Set the package manager to point to the Togan build server by default
- Affected hardware: ALL 
- Issue: #117

## Build and test
- [x] Build command: built for all supported platforms
- [x] Smoke tested on: BF2556X-1T
