### PR TITLE
Change note on cronie.sh arg order in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ source openembedded-core/oe-init-build-env
 ../cronie.sh -m <machine> <image>
 ```
 
-> **NOTE: The \<image\> argument must be provided last**
+**NOTE: The \<image\> argument must be provided last**
 
 To do a "dry run" without running a build, add `-e` which emits what would have
 run if you ran this from bitbake.


### PR DESCRIPTION
The README was changed so that the note on providing image name last was
placed in bold text to increase the likelihood of it being noticed.

This applies to mion #140 

Signed-off-by: Katrina Prosise <igorina@toganlabs.com>

# repo: mion

- Issue: #140 

- Affected hardware: N/A
- Build command: Checked rendering of markdown with grip
- Tested on: N/A

- Description: Increase visibility of "cronie.sh argument order" note in README.md
