### PR TITLE
Update build script arg use for cronie.sh help

### DIFF
--- a/cronie.sh
+++ b/cronie.sh
@@ -6,7 +6,9 @@ error() { echo "ERROR: $1" >&2; exit 1; }
 
 usage(){
     cat <<EOF
-$(basename $0) [options] image_name -or- bitbake_command
+$(basename $0) [options] image_name
+
+NOTE: Options must be give BEFORE image name
 
 options:
     -e (optional emit bitbake line. Doesn't run a build, just emits what would run.)


### PR DESCRIPTION
Updated the help section of `cronie.sh` to mention that all args must be
provided before the image type.

Tested using `../cronie.sh` with no args, and ran
`../cronie.sh -m qemux86-64 -v qemu -k mion-image-onlpv1` to check.

This applies to mion #140.

Signed-off-by: Katrina Prosise <igorina@toganlabs.com>

# repo: mion

- Issue: #?

- Affected hardware: ALL -or- _specific switches_
- Build command: cronie.sh ...
- Tested on: _switch model_

- Description: _brief description of issue or enhancment_
