### PR TITLE
Cronie Improvements

### DIFF
--- a/cronie.sh
+++ b/cronie.sh
@@ -20,8 +20,10 @@ EOF
 [ -z "$BBPATH" ] && error "Please source ./openembedded-core/oe-init-build-env before running this script"
 [ $# -eq 0 ] && usage
 
-while getopts "em:kv:" opt; do
+while getopts "fcem:kv:" opt; do
     case ${opt} in
+        f ) FORCE="-f" ;;
+        c ) COMMAND="-c ${OPTARG}" ;;
         e ) EMIT=true ;;
         m ) MACHINE=${OPTARG} ;;
         k ) CONTINUE="--continue" ;;
@@ -39,9 +41,9 @@ BITBAKE_ARGS="$*"
 
 if [ "${EMIT}" = "true" ]; then 
     cat <<EOF
-BB_ENV_EXTRAWHITE="$BB_ENV_EXTRAWHITE VENDOR" VENDOR="$VENDOR" MACHINE="$MACHINE" bitbake ${CONTINUE} "${BITBAKE_ARGS}"
+BB_ENV_EXTRAWHITE="$BB_ENV_EXTRAWHITE VENDOR" VENDOR="$VENDOR" MACHINE="$MACHINE" bitbake ${FORCE} ${COMMAND} ${CONTINUE} ${BITBAKE_ARGS}
 EOF
     exit
 fi
 
-exec env BB_ENV_EXTRAWHITE="$BB_ENV_EXTRAWHITE VENDOR" VENDOR="$VENDOR" MACHINE="$MACHINE" bitbake ${CONTINUE} "${BITBAKE_ARGS}"
+exec env BB_ENV_EXTRAWHITE="$BB_ENV_EXTRAWHITE VENDOR" VENDOR="$VENDOR" MACHINE="$MACHINE" bitbake ${FORCE} ${COMMAND} ${CONTINUE} ${BITBAKE_ARGS}


### PR DESCRIPTION
# repo: mion

- Affected hardware: ALL
- Build command: n/a
- Tested on: n/a

BitBake is capable of building multiple packages in one invocation, by providing
more than one package name. Cronie currently quotes the package argument, so
supplying multiple packages will appear as a single package to bitbake. This
commit reverts the quotes.

It also adds the following arguments:

   -f ) Force operation
   -c ) Command to apply

This is useful if you want to clean the shared state or otherwise clean a bunch
of packages, without having to run "cronie.sh -e ... " and grabbing all of the
environment setup.
